### PR TITLE
Added logging for restarting/updating

### DIFF
--- a/bot/Config.sample/config.ini
+++ b/bot/Config.sample/config.ini
@@ -6,6 +6,7 @@ jira url =
 opsgenie =
 
 [general]
+log channel id =
 autoload cogs:
     tickets
     fun

--- a/bot/dev.py
+++ b/bot/dev.py
@@ -25,6 +25,14 @@ class dev(commands.Cog):
         self.bot = bot
 
     @commands.Cog.listener()
+    async def on_ready(self):
+        """
+        Sends message when the bot is ready
+        """
+        embed = discord.Embed(title="Bot online!")
+        await self.bot.get_channel(config["general"]["log channel id"]).send(embed=embed)
+
+    @commands.Cog.listener()
     async def on_guild_join(self, guild):
         """
         Sends message when the bot is added to a server

--- a/bot/update.py
+++ b/bot/update.py
@@ -4,8 +4,8 @@ Automatically updates the bot when there are changes to master
 import time
 import configparser
 from subprocess import call
-from asyncio import sleep
 
+import discord
 from discord.ext import commands
 
 from core import trusted

--- a/bot/update.py
+++ b/bot/update.py
@@ -2,6 +2,7 @@
 Automatically updates the bot when there are changes to master
 """
 import time
+import configparser
 from subprocess import call
 from asyncio import sleep
 
@@ -9,6 +10,8 @@ from discord.ext import commands
 
 from core import trusted
 
+config = configparser.ConfigParser()
+config.read("Config/config.ini")
 
 class update(commands.Cog):
     """
@@ -24,8 +27,11 @@ class update(commands.Cog):
         """
         if message.channel.id == 761747494693765151 and message.embeds:
             if " new commit" in message.embeds[0].title and message.embeds[0].title.startswith("[Sudan-bot:master] "):
-                await sleep(15)
+                embed = discord.Embed(title="Update detected pulling...")
+                await self.bot.get_channel(config["general"]["log channel id"]).send(embed=embed)
                 call(["git", "pull"])
+                embed = discord.Embed(title="Restarting/stopping...")
+                await self.bot.get_channel(config["general"]["log channel id"]).send(embed=embed)
                 await self.bot.close()
 
     @commands.command()
@@ -36,6 +42,8 @@ class update(commands.Cog):
         """
         start_time = time.time()
         msg = await ctx.send("updating...")
+        embed = discord.Embed(title="Pulling update...")
+        await self.bot.get_channel(config["general"]["log channel id"]).send(embed=embed)
         call(["git", "pull"])
         await msg.edit(f"updating... DONE!(took {time.time()-start_time}ms)")
 
@@ -46,6 +54,8 @@ class update(commands.Cog):
         Stops the bot
         """
         await ctx.send("stopping...")
+        embed = discord.Embed(title="Restarting/stopping...")
+        await self.bot.get_channel(config["general"]["log channel id"]).send(embed=embed)
         await self.bot.close()
 
 


### PR DESCRIPTION
<!-- Put info up here NOT AT THE END -->
This PR makes it so that when the bot is restarted or updated it sends a message

**BREAKING CHANGE:** The bot will not start unless you add `log channel id = <channel id>` under the `general` section in `bot/Config/config.ini`

# Issue
<!-- If this PR resolves or is related to a jira issue put the issue's key on the next line (eg. SDB-123) delete this heading if this is not applicable -->
SDB-60

# Checklist
<!-- Replace space between brackets with x to tick a box -->
- [ ] This PR has been tested
	- [ ] Everything still works
	- [ ] No major bugs have been made
		- [ ] I have listed minor bugs that have been added
- [x] I have listed all changes that this PR makes
- [x] This PR needs no further work
- [x] Manual restart and/or configuration required post-merge
- [ ] README.md or other documentation will be updated by this PR
- [x] I have listed how to make bot work again post-merge <!--  -->

<!-- Only tick one in each set -->
- [ ] This is a major change
- [x] This is a minor change
<p/>

- [ ] This is a bug fix
- [x] This is an enhancement or new feature
- [ ] Other: <!-- specify here if you choose this (replace everything between < and >) -->
