### PR TITLE
Made it so that server moderators can stop people on sudoing

### DIFF
--- a/bot/fun.py
+++ b/bot/fun.py
@@ -35,6 +35,7 @@ class fun(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
+    @commands.check(lambda ctx: "sudont" not in [role.name for role in ctx.author.roles])
     async def sudo(self, ctx, user: discord.Member, *, message):
         """
         Mimics another user


### PR DESCRIPTION
<!-- Put info up here NOT AT THE END -->
This will make it so that server moderators can give a role named `sudont` and then that user cant use sudo

<!--# Issue
<!-- If this PR resolves or is related to a jira issue put the issue's key on the next line (eg. SDB-123) delete this heading if this is not applicable -->


# Checklist
<!-- Replace space between brackets with x to tick a box -->
- [ ] This PR has been tested
	- [ ] Everything still works
	- [ ] No major bugs have been made
		- [ ] I have listed minor bugs that have been added
- [x] I have listed all changes that this PR makes
- [x] This PR needs no further work
- [ ] Manual restart and/or configuration required post-merge
- [ ] README.md or other documentation will be updated by this PR
- [ ] I have listed how to make bot work again post-merge <!--  -->

<!-- Only tick one in each set -->
- [ ] This is a major change
- [x] This is a minor change
<p/>

- [ ] This is a bug fix
- [x] This is an enhancement or new feature
- [ ] Other: <!-- specify here if you choose this (replace everything between < and >) -->
