### PR TITLE
Moved pip install to install dependancies

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -19,8 +19,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
+        pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pip install -r requirements.txt
         cd bot
         pylint --good-names `ls -d *.py -m | sed s/.py//g | sed 's/ //g' | tr -d '\n'` -d R0801,C0301,R0903,R0912,W0122,W0123 `ls -R|grep .py$|xargs`


### PR DESCRIPTION
This is so that when looking at the output of Pylint it doesn't show pip installing stuff

<!-- Put info up here NOT AT THE END -->





# Checklist
<!-- Replace space between brackets with x to tick a box -->
- [ ] This PR has been tested
	- [ ] Everything still works
	- [ ] No major bugs have been made
		- [ ] I have listed minor bugs that have been added
- [x] I have listed all changes that this PR makes
- [x] This PR needs no further work
- [ ] Manual restart and/or configuration required post-merge
- [ ] README.md or other documentation will be updated by this PR
- [ ] I have listed how to make bot work again post-merge <!--  -->

<!-- Only tick one in each set -->
- [ ] This is a major change
- [x] This is a minor change
<p/>

- [ ] This is a bug fix
- [ ] This is an enhancement or new feature
- [x] Other: GH actions
