### PR TITLE
Made pylint skip _util.py

### DIFF
--- a/bot/_util.py
+++ b/bot/_util.py
@@ -1,6 +1,8 @@
 """
 Stuff that is shared between all cogs
 """
+# pylint: skip-file
+# TODO: Make checks work properly
 # colours
 BLUE = 0x0a8cf0
 PURPLE = 0x6556FF


### PR DESCRIPTION
This will allow the other PRs to be merged by telling pylint to skip _util.py



# Checklist
<!-- Replace space between brackets with x to tick a box -->
- [ ] This PR has been tested
	- [ ] Everything still works
	- [ ] No major bugs have been made
		- [ ] I have listed minor bugs that have been added
- [x] I have listed all changes that this PR makes
- [x] This PR needs no further work
- [ ] Manual restart and/or configuration required post-merge
	- [ ] I have listed how to make bot work again post-merge
- [ ] README.md or other documentation will be updated by this PR

<!-- Only tick one in each set -->
- [ ] This is a major change
- [x] This is a minor change
<p/>

- [ ] This is a bug fix
- [ ] This is an enhancement or new feature
- [x] Other: GH actions change
