### PR TITLE
Added option to enforce slash command usage

### DIFF
--- a/Setup_DB.sql
+++ b/Setup_DB.sql
@@ -2,7 +2,7 @@ CREATE TABLE guilds
 (id BIGINT PRIMARY KEY, mod_roles BIGINT[], admin_roles BIGINT[],
 ticket_category BIGINT, ticket_log_channel BIGINT, support_roles BIGINT[],
 ticket_ban_role BIGINT, ticket_index INT, chain_break_role BIGINT,
-private_commands BOOLEAN);
+private_commands BOOLEAN, forced_slash BOOLEAN);
 
 CREATE TABLE users
 (id BIGINT PRIMARY KEY, trusted BOOLEAN, dad_mode BOOLEAN, mc_uuid TEXT);

--- a/bot/_util.py
+++ b/bot/_util.py
@@ -51,3 +51,10 @@ class Checks:
             if role in [r.id for r in ctx.author.roles]:
                 return True
         return False
+
+    @staticmethod
+    async def slash(ctx):
+        """
+        Check to see if command has slash command alternative
+        """
+        return not await _DB.fetchval("SELECT force_slash FROM guilds WHERE id = $1", ctx.guild.id)

--- a/bot/core.py
+++ b/bot/core.py
@@ -156,6 +156,7 @@ class core(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
+    @commands.check(Checks.slash)
     async def invite(self, ctx):
         """
         Gives invite for you to invite bot to your own server
@@ -204,6 +205,7 @@ class core(commands.Cog):
         await self.bot.change_presence(status=statuses[os.getenv("STATUS")], activity=activity)
 
     @commands.command()
+    @commands.check(Checks.slash)
     async def github(self, ctx):
         """
         Links to github

--- a/bot/info.py
+++ b/bot/info.py
@@ -6,7 +6,7 @@ import emc
 from emc.async_ import get_data
 from discord.ext import commands
 
-from _util import RED, BLUE
+from _util import RED, BLUE, Checks, set_db
 
 
 def _long_fields(embed, title, list_):
@@ -26,8 +26,10 @@ class info(commands.Cog):
     """
     def __init__(self, bot):
         self.bot = bot
+        set_db(bot.db)
 
     @commands.command(aliases=["t"])
+    @commands.check(Checks.slash)
     async def town(self, ctx, town_to_find):
         """
         Gives info about a town
@@ -59,6 +61,7 @@ class info(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command(aliases=["n"])
+    @commands.check(Checks.slash)
     async def nation(self, ctx, nation_to_find="Sudan"):
         """Gives info about a nation"""
         await ctx.message.delete()
@@ -82,6 +85,7 @@ class info(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command(aliases=["res", "player", "pl"])
+    @commands.check(Checks.slash)
     async def resident(self, ctx, resident_to_find):
         """Gives info about a player"""
         await ctx.message.delete()

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -15,6 +15,7 @@ class settings(commands.Cog):
         self.bot = bot
 
     @commands.group(invoke_without_command=True, aliases=["set"])
+    @commands.check(Checks.slash)
     async def settings(self, ctx):
         """Lists settings"""
         await ctx.message.delete()
@@ -38,6 +39,7 @@ class settings(commands.Cog):
 
     @settings.group(invoke_without_command=True)
     @commands.check(Checks.admin)
+    @commands.check(Checks.slash)
     async def admin(self, ctx):
         """Lists admin roles"""
         roles = await self.bot.db.fetchval("SELECT admin_roles FROM guilds WHERE id = $1", ctx.guild.id)
@@ -48,6 +50,7 @@ class settings(commands.Cog):
 
     @admin.command(name="set")
     @commands.check(lambda ctx: ctx.author == ctx.guild.owner)
+    @commands.check(Checks.slash)
     async def admin_set(self, ctx, role: discord.Role):
         """Sets the server's admin role"""
         await ctx.message.delete()
@@ -62,6 +65,7 @@ class settings(commands.Cog):
 
     @admin.command(name="add")
     @commands.check(Checks.admin)
+    @commands.check(Checks.slash)
     async def admin_add(self, ctx, role: discord.Role):
         """Adds an admin role"""
         await ctx.message.delete()
@@ -72,6 +76,7 @@ class settings(commands.Cog):
 
     @admin.command(name="remove")
     @commands.check(Checks.admin)
+    @commands.check(Checks.slash)
     async def admin_remove(self, ctx, role: discord.Role):
         """Removes an admin role"""
         await ctx.message.delete()
@@ -82,6 +87,7 @@ class settings(commands.Cog):
 
     @settings.group(invoke_without_command=True)
     @commands.check(Checks.admin)
+    @commands.check(Checks.slash)
     async def mod(self, ctx):
         """Lists moderator roles"""
         roles = await self.bot.db.fetchval("SELECT mod_roles FROM guilds WHERE id = $1", ctx.guild.id)
@@ -92,6 +98,7 @@ class settings(commands.Cog):
 
     @mod.command(name="add")
     @commands.check(Checks.admin)
+    @commands.check(Checks.slash)
     async def mod_add(self, ctx, role: discord.Role):
         """Adds moderator role"""
         await ctx.message.delete()
@@ -102,6 +109,7 @@ class settings(commands.Cog):
 
     @mod.command(name="remove")
     @commands.check(Checks.admin)
+    @commands.check(Checks.slash)
     async def mod_remove(self, ctx, role: discord.Role):
         """Removes moderator role"""
         await ctx.message.delete()
@@ -112,6 +120,7 @@ class settings(commands.Cog):
 
     @settings.group(invoke_without_command=True)
     @commands.check(Checks.admin)
+    @commands.check(Checks.slash)
     async def support(self, ctx):
         """Lists ticket support roles"""
         roles = await self.bot.db.fetchval("SELECT support_roles FROM guilds WHERE id = $1", ctx.guild.id)
@@ -122,6 +131,7 @@ class settings(commands.Cog):
 
     @support.command(name="add")
     @commands.check(Checks.admin)
+    @commands.check(Checks.slash)
     async def support_add(self, ctx, role: discord.Role):
         """Adds ticket support role"""
         await ctx.message.delete()
@@ -132,6 +142,7 @@ class settings(commands.Cog):
 
     @support.command(name="remove")
     @commands.check(Checks.admin)
+    @commands.check(Checks.slash)
     async def support_remove(self, ctx, role: discord.Role):
         """Removes ticket support role"""
         await ctx.message.delete()
@@ -142,6 +153,7 @@ class settings(commands.Cog):
 
     @settings.command()
     @commands.check(Checks.admin)
+    @commands.check(Checks.slash)
     async def breakrole(self, ctx, role: discord.Role):
         """Sets the chain break role"""
         await ctx.message.delete()
@@ -152,6 +164,7 @@ class settings(commands.Cog):
 
     @settings.command()
     @commands.check(Checks.admin)
+    @commands.check(Checks.slash)
     async def private(self, ctx, toggle: bool):
         """Enables or disables private commands"""
         await ctx.message.delete()
@@ -171,6 +184,7 @@ class settings(commands.Cog):
         await ctx.send(embed=embed)
 
     @settings.command()
+    @commands.check(Checks.slash)
     async def dad(self, ctx, toggle: bool):
         """Enables or disables dad mode"""
         await ctx.message.delete()

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -27,6 +27,7 @@ class settings(commands.Cog):
                 Ticket support roles: {', '.join([f'<@&{role}>' for role in settings_["support_roles"]]) if len(settings_['support_roles']) > 0 else 'None'}
                 Chain break role: {f'<@&{settings_["chain_break_role"]}>' if settings_["chain_break_role"] is not None else 'None'}
                 Private commands: {'🟢' if settings_['private_commands'] else '🔴'}
+                Force slash commands: {'🟢' if settings_['force_slash'] else '🔴'}
             """)
         settings_ = await self.bot.db.fetchrow("SELECT * FROM users WHERE id = $1", ctx.author.id)
         embed.add_field(name="User settings", inline=False, value=f"""
@@ -156,6 +157,16 @@ class settings(commands.Cog):
         await ctx.message.delete()
         await self.bot.db.execute("UPDATE guilds SET private_commands = $2 WHERE id = $1", ctx.guild.id, toggle)
         embed = discord.Embed(title="Settings updated", description=f"{'Enabled' if toggle else 'Disabled'} private commands", colour=GREEN)
+        embed.set_author(name=ctx.author.nick if ctx.author.nick else ctx.author.name, icon_url=ctx.author.avatar_url)
+        await ctx.send(embed=embed)
+
+    @settings.command()
+    @commands.check(Checks.admin)
+    async def forceslash(self, ctx, toggle: bool):
+        """Enables or disables forced slash command usage"""
+        await ctx.message.delete()
+        await self.bot.db.execute("UPDATE guilds SET force_slash = $2 WHERE id = $1", ctx.guild.id, toggle)
+        embed = discord.Embed(title="Settings updated", description=f"{'Enabled' if toggle else 'Disabled'} forced slash commands", colour=GREEN)
         embed.set_author(name=ctx.author.nick if ctx.author.nick else ctx.author.name, icon_url=ctx.author.avatar_url)
         await ctx.send(embed=embed)
 

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,19 @@ post(DISCORD + "/commands", headers=HEADERS, json={
                             "required": True
                         }
                     ]
+                },
+                {
+                    "type": 1,
+                    "name": "forceslash",
+                    "description": "Set if slash command usage should be enforced",
+                    "options": [
+                        {
+                            "type": 5,
+                            "name": "value",
+                            "description": "Value to set force slash commands to",
+                            "required": True
+                        }
+                    ]
                 }
             ]
         }

--- a/slash/app.py
+++ b/slash/app.py
@@ -329,7 +329,7 @@ def settings(ctx, private):
         if Checks.admin(ctx):
             with db.cursor() as curr:
                 curr.execute(
-                    "SELECT admin_roles, mod_roles, support_roles, chain_break_role, private_commands FROM guilds WHERE id = %s",
+                    "SELECT admin_roles, mod_roles, support_roles, chain_break_role, private_commands, force_slash FROM guilds WHERE id = %s",
                     (ctx["guild_id"],))
                 settings = curr.fetchone()
             message += f"""
@@ -338,7 +338,8 @@ Admin roles: {', '.join([f'<@&{role}>' for role in settings[0]]) if len(settings
 Moderator roles: {', '.join([f'<@&{role}>' for role in settings[1]]) if len(settings[1]) > 0 else 'None'}
 Ticket support roles: {', '.join([f'<@&{role}>' for role in settings[2]]) if len(settings[2]) > 0 else 'None'}
 Chain break role: {f'<@&{settings[3]}>' if settings[3] is not None else 'None'}
-Private commands: {'🟢' if settings[4] else '🔴'}"""
+Private commands: {'🟢' if settings[4] else '🔴'}
+Force slash commands: {'🟢' if settings[5] else '🔴'}"""
         with db.cursor() as curr:
             curr.execute("SELECT dad_mode FROM users WHERE id = %s",
                          (ctx["member"]["user"]["id"],))

--- a/slash/app.py
+++ b/slash/app.py
@@ -509,3 +509,20 @@ def set(ctx, private):
                     "color": GREEN
                 }]
             }
+
+        elif ctx["data"]["options"][0]["options"][0]["name"] == "forceslash":
+            with db.cursor() as curr:
+                curr.execute("UPDATE guilds SET force_slash = %s WHERE id = %s", (
+                        ctx["data"]["options"][0]["options"][0]["options"][0]["value"],
+                        int(ctx["guild_id"])
+                    ))
+                db.commit()
+            if private:
+                return {"content": f"{'Enabled' if ctx['data']['options'][0]['options'][0]['options'][0]['value'] else 'Disabled'} force slash commands"}
+            return {
+                "embeds": [{
+                    "title": "Settings updated",
+                    "description": f"{'Enabled' if ctx['data']['options'][0]['options'][0]['options'][0]['value'] else 'Disabled'} force slash commands",
+                    "color": GREEN
+                }]
+            }


### PR DESCRIPTION
Added force slash setting, when enabled commands with slash command alternative will be disabled.

Fixed #177

# Checklist
<!-- Replace space between brackets with x to tick a box -->
- [x] This PR has been tested
	- [x] Everything still works
	- [x] No major bugs have been made
		- [ ] I have listed minor bugs that have been added
- [x] I have listed all changes that this PR makes
- [x] This PR needs no further work
- [ ] Manual restart and/or configuration required post-merge
	- [ ] I have listed how to make bot work again post-merge
- [ ] README.md or other documentation will be updated by this PR

<!-- Only tick one in each set -->
- [ ] This is a major change
- [x] This is a minor change
<p/>

- [ ] This is a bug fix
- [x] This is an enhancement or new feature
- [ ] Other: <!-- specify here if you choose this (replace everything between < and >) -->
