### PR TITLE
Better chain

### DIFF
--- a/Setup_DB.sql
+++ b/Setup_DB.sql
@@ -12,7 +12,8 @@ CREATE TABLE users
 
 CREATE TABLE channels
 (id BIGINT PRIMARY KEY, guild_id BIGINT, chain TEXT,
-chain_length INTEGER, log_type TEXT, last_chain BIGINT);
+chain_length INTEGER, log_type TEXT, last_chain BIGINT,
+chain_forever TEXT);
 
 CREATE TABLE rules
 (name TEXT, guild_id BIGINT, punishment TEXT, description TEXT);

--- a/app.json
+++ b/app.json
@@ -24,12 +24,17 @@
       "description": "The region for Microsoft translate, only required for the translate cog",
       "required": false
     },
+    "CHAIN_PIN_THRESHOLD": {
+      "description": "Threshold to pin break messages for chainforever, only required for the fun cog",
+      "value": "25",
+      "required": false
+    },
     "LOG_CHANNEL": {
       "description": "The ID of the channel you want the bot to use to say that it is online"
     },
     "AUTOLOAD_COGS": {
       "description": "Comma seperated list of cogs to load when the bot starts",
-      "value": "tickets,fun,gamerooms,utils,dev,settings,rules,linking,log,info"
+      "value": "Tickets,Fun,Utils,Dev,Settings,Rules,Linking,Log,Info,Moderation"
     },
     "ACTIVITY_TYPE": {
       "description": "The type of activity, must be playing, watching, streaming, listening, competing or custom",

--- a/bot/.env.sample
+++ b/bot/.env.sample
@@ -2,10 +2,15 @@
 
 #API CREDENTIALS
 
+#The bot's token
 BOT_TOKEN=
+#The public key for the Discord API application
 PUBLIC_KEY=
+#The API token for Opsgenie, only required for the errors cog
 OPSGENIE_TOKEN=
+#API key for Microsoft translate, only required for the translate cog
 MICROSOFT_TRANSLATE_KEY=
+#The region for Microsoft translate, only required for the translate cog
 MICROSOFT_TRANSLATE_REGION=
 
 #POSTRESQL CREDENTIALS
@@ -18,13 +23,17 @@ DB_DATABASE=
 
 #CONFIG
 
-#channel(id) to log stuff
+#Channel(id) to log stuff
 LOG_CHANNEL=
-#list of cogs to autoload when the bot starts
-AUTOLOAD_COGS=
-ACTIVITY=
+#List of cogs to autoload when the bot starts
+AUTOLOAD_COGS=Tickets,Fun,Utils,Dev,Settings,Rules,Linking,Log,Info,Moderation
+#The bot's activity
+ACTIVITY="my owner set me up"
 #playing, watching, streaming, listening, competing or custom
-ACTIVITY_TYPE=
+ACTIVITY_TYPE=watching
 #online, idle, dnd, invisible
-STATUS=
-PREFIXES=
+STATUS=idle
+#Comma seperated list of prefixes
+PREFIXES=.,/,&
+#Threshold to pin break messages for chainforever, only required for the fun cog
+CHAIN_PIN_THRESHOLD=25

--- a/bot/Fun.py
+++ b/bot/Fun.py
@@ -111,7 +111,7 @@ class Fun(commands.Cog):
                 break_role = await db.fetchval("SELECT chain_break_role FROM guilds WHERE id = $1", msg.guild.id)
                 if break_role is not None:
                     await msg.author.add_roles(msg.guild.get_role(break_role))
-                await db.execute("UPDATE channels SET chain = $2, chain_length = 0 WHERE id = $1", msg.channel.id, forever)
+                await db.execute("UPDATE channels SET chain = $2, chain_length = 0, last_chain = NULL WHERE id = $1", msg.channel.id, forever)
 
             if chain is None or msg.author.bot:
                 return

--- a/bot/Fun.py
+++ b/bot/Fun.py
@@ -2,7 +2,6 @@
 Contains fun stuff
 """
 import re
-import asyncio
 
 import discord
 from discord.ext import commands
@@ -59,48 +58,48 @@ class Fun(commands.Cog):
         """
         Checks to see if chain is broken
         """
-        chain = await self.bot.db.fetchval("SELECT chain FROM channels WHERE id = $1", msg.channel.id)
+        async with self.bot.pool.acquire() as db:
+            chain = await db.fetchval("SELECT chain FROM channels WHERE id = $1", msg.channel.id)
+            length = await db.fetchval("SELECT chain_length FROM channels WHERE id = $1", msg.channel.id)
 
-        async def cbreak():
-            """
-            If the chain is broken say so and update DB
-            """
-            if msg.content.endswith(f"chain {chain}"):
+            async def cbreak():
+                """
+                If the chain is broken say so and update DB
+                """
+                if msg.content.endswith(f"chain {chain}"):
+                    return
+                await msg.add_reaction("❌")
+                await msg.channel.send(f"{msg.author.mention} broke the chain! start a new chain with `.chain <thing>`. Chain length: {length}")
+                break_role = await db.fetchval("SELECT chain_break_role FROM guilds WHERE id = $1", msg.guild.id)
+                if break_role is not None:
+                    await msg.author.add_roles(msg.guild.get_role(break_role))
+                await db.execute("UPDATE channels SET chain = NULL, chain_length = 0 WHERE id = $1", msg.channel.id)
+
+            if chain is None or msg.author.bot:
                 return
-            await msg.add_reaction("❌")
-            await msg.channel.send(
-                f"{msg.author.mention} broke the chain! start a new chain with `.chain <thing>`. Chain length: {await self.bot.db.fetchval('SELECT chain_length FROM channels WHERE id = $1', msg.channel.id)}")
-            break_role = await self.bot.db.fetchval("SELECT chain_break_role FROM guilds WHERE id = $1", msg.guild.id)
-            if break_role is not None:
-                await msg.author.add_roles(msg.guild.get_role(break_role))
-            await self.bot.db.execute(
-                "UPDATE channels SET chain = NULL, chain_length = 0 WHERE id = $1",
-                msg.channel.id)
-
-        if chain is None or msg.author.bot:
-            return
-        if chain.startswith("$counting:"):
-            num = int(chain.split(":")[1])
-            if msg.content != str(num + 1):
+            if chain.startswith("$counting:"):
+                num = int(chain.split(":")[1])
+                if msg.content != str(num + 1):
+                    await cbreak()
+                else:
+                    num += 1
+                    await db.execute("UPDATE channels SET chain = $2 WHERE id = $1", msg.channel.id, f"$counting:{num}")
+            elif msg.content != chain or msg.author.id == await db.fetchval("SELECT last_chain FROM channels WHERE id = $1", msg.channel.id):
                 await cbreak()
             else:
-                num += 1
-                await self.bot.db.execute("UPDATE channels SET chain = $2 WHERE id = $1", msg.channel.id, f"$counting:{num}")
-        elif msg.content != chain or msg.author.id == await self.bot.db.fetchval("SELECT last_chain FROM channels WHERE id = $1", msg.channel.id):
-            await cbreak()
-        else:
-            await self.bot.db.execute("UPDATE channels SET last_chain = $2, chain_length = chain_length + 1 WHERE id = $1", msg.channel.id, msg.author.id)
-            if msg.content == "100":
-                await msg.add_reaction("💯")
-            else:
-                await msg.add_reaction("✅")
+                await db.execute("UPDATE channels SET last_chain = $2, chain_length = chain_length + 1 WHERE id = $1", msg.channel.id, msg.author.id)
+                if msg.content == "100":
+                    await msg.add_reaction("💯")
+                else:
+                    await msg.add_reaction("✅")
 
     async def dad_mode(self, message):
         """
         dad mode
         """
-        if not await self.bot.db.fetchval("SELECT dad_mode FROM users WHERE id = $1", message.author.id):
-            return
+        async with self.bot.pool.acquire() as db:
+            if not await db.fetchval("SELECT dad_mode FROM users WHERE id = $1", message.author.id):
+                return
         phrases = {
             "i am {}": "Hi {}! I am Dad",
             "i'm {}": "Hi {}! I'm Dad",
@@ -118,9 +117,7 @@ class Fun(commands.Cog):
         """
         runs stuff that has to run on_message
         """
-        await asyncio.sleep(.1)
         await self.dad_mode(message)
-        await asyncio.sleep(.1)
         await self.chain_check(message)
 
 

--- a/bot/Fun.py
+++ b/bot/Fun.py
@@ -80,18 +80,18 @@ class Fun(commands.Cog):
             if chain.startswith("$counting:"):
                 num = int(chain.split(":")[1])
                 if msg.content != str(num + 1):
-                    await cbreak()
-                else:
-                    num += 1
-                    await db.execute("UPDATE channels SET chain = $2 WHERE id = $1", msg.channel.id, f"$counting:{num}")
-            elif msg.content != chain or msg.author.id == await db.fetchval("SELECT last_chain FROM channels WHERE id = $1", msg.channel.id):
-                await cbreak()
+                    return await cbreak()
+                num += 1
+                await db.execute("UPDATE channels SET chain = $2 WHERE id = $1", msg.channel.id, f"$counting:{num}")
+            elif msg.content != chain:
+                return await cbreak()
+            if msg.author.id == await db.fetchval("SELECT last_chain FROM channels WHERE id = $1", msg.channel.id):
+                return await cbreak()
+            await db.execute("UPDATE channels SET last_chain = $2, chain_length = chain_length + 1 WHERE id = $1", msg.channel.id, msg.author.id)
+            if msg.content == "100" or length == 100:
+                await msg.add_reaction("💯")
             else:
-                await db.execute("UPDATE channels SET last_chain = $2, chain_length = chain_length + 1 WHERE id = $1", msg.channel.id, msg.author.id)
-                if msg.content == "100":
-                    await msg.add_reaction("💯")
-                else:
-                    await msg.add_reaction("✅")
+                await msg.add_reaction("✅")
 
     async def dad_mode(self, message):
         """

--- a/bot/Fun.py
+++ b/bot/Fun.py
@@ -45,14 +45,14 @@ class Fun(commands.Cog):
         """
         Starts a chain
         """
-        await self.bot.db.execute("UPDATE channels SET last_chain = NULL WHERE id = $1", ctx.channel.id)
-        await self.bot.db.execute(
-            "UPDATE channels SET chain = $2 WHERE id = $1", ctx.channel.id,
-            thing)
         if thing.startswith("$counting:"):
-            await ctx.send(f"Counting started at: {thing.split(':')[1]}")
+            if thing.split(":", 1)[1] == "" or any(char not in "0123456789" for char in thing.split(":", 1)[1]) or thing.split(":", 1)[1][0] == "0":
+                raise commands.BadArgument
+            await ctx.send(f"Counting started at: {thing.split(':', 1)[1]}")
         else:
             await ctx.send(f"New chain: {thing}")
+        await self.bot.db.execute("UPDATE channels SET last_chain = NULL WHERE id = $1", ctx.channel.id)
+        await self.bot.db.execute("UPDATE channels SET chain = $2 WHERE id = $1", ctx.channel.id, thing)
 
     async def chain_check(self, msg):
         """

--- a/bot/Fun.py
+++ b/bot/Fun.py
@@ -10,6 +10,12 @@ from discord.ext import commands
 from _Util import Checks, GREEN, RED
 
 
+async def check_no_chain_forever(ctx):
+    """Check that chainforever is not active"""
+    async with ctx.bot.pool.acquire() as db:
+        return await db.fetchval("SELECT chain_forever FROM channels WHERE id = $1", ctx.channel.id) is None
+
+
 class Fun(commands.Cog):
     """
     The main class for this file
@@ -43,6 +49,7 @@ class Fun(commands.Cog):
                            avatar_url=user.avatar_url)
         await webhook.delete()
 
+    @commands.check(check_no_chain_forever)
     @commands.command()
     async def chain(self, ctx, *, thing):
         """

--- a/bot/Fun.py
+++ b/bot/Fun.py
@@ -2,9 +2,12 @@
 Contains fun stuff
 """
 import re
+from os import getenv
 
 import discord
 from discord.ext import commands
+
+from _Util import Checks, GREEN, RED
 
 
 class Fun(commands.Cog):
@@ -51,44 +54,73 @@ class Fun(commands.Cog):
             await ctx.send(f"Counting started at: {thing.split(':', 1)[1]}")
         else:
             await ctx.send(f"New chain: {thing}")
-        await self.bot.db.execute("UPDATE channels SET last_chain = NULL WHERE id = $1", ctx.channel.id)
-        await self.bot.db.execute("UPDATE channels SET chain = $2 WHERE id = $1", ctx.channel.id, thing)
+        await self.bot.db.execute("UPDATE channels SET last_chain = NULL, chain = $2 WHERE id = $1", ctx.channel.id, thing)
+
+    @commands.check(Checks.admin)
+    @commands.command()
+    async def chainforever(self, ctx, *, thing=None):
+        """Starts a chain that restarts when broken"""
+        await ctx.message.delete()
+        if thing is None:
+            embed = discord.Embed(title="Chain disabled", colour=RED)
+        else:
+            if thing.startswith("$counting:"):
+                if thing.split(":", 1)[1] == "" or any(char not in "0123456789" for char in thing.split(":", 1)[1]) or thing.split(":", 1)[1][0] == "0":
+                    raise commands.BadArgument
+            embed = discord.Embed(title="Chain updated", description=f"New chain: {thing}", colour=GREEN)
+        await self.bot.db.execute("UPDATE channels SET last_chain = NULL, chain_forever = $2, chain = $2 WHERE id = $1", ctx.channel.id, thing)
+        embed.set_author(name=ctx.author.display_name, icon_url=ctx.author.avatar_url)
+        await ctx.send(embed=embed)
 
     async def chain_check(self, msg):
         """
         Checks to see if chain is broken
         """
+        if isinstance(msg.channel, discord.DMChannel):
+            return
+        bot = self.bot
         async with self.bot.pool.acquire() as db:
-            chain = await db.fetchval("SELECT chain FROM channels WHERE id = $1", msg.channel.id)
-            length = await db.fetchval("SELECT chain_length FROM channels WHERE id = $1", msg.channel.id)
+            chain_ = await db.fetchrow("SELECT chain, chain_length, chain_forever FROM channels WHERE id = $1", msg.channel.id)
+            chain = chain_["chain"]
+            length = chain_["chain_length"]
+            forever = chain_["chain_forever"]
 
             async def cbreak():
                 """
                 If the chain is broken say so and update DB
                 """
-                if msg.content.endswith(f"chain {chain}"):
-                    return
+                if forever is not None:
+                    if any(msg.content.startswith(f"{prefix}chainforever") for prefix in getenv("PREFIXES").split(",")) and await Checks.admin(msg, bot):
+                        return
+                    embed = discord.Embed(title="Chain broken!", description=f"{msg.author.mention} broke the chain!", colour=RED)
+                    embed.add_field(name="Length", value=length)
+                    embed.set_author(name=msg.author.display_name, icon_url=msg.author.avatar_url)
+                    message = await msg.reply(embed=embed)
+                    if length >= int(getenv("CHAIN_PIN_THRESHOLD")):
+                        await message.pin()
+                else:
+                    await msg.channel.send(f"{msg.author.mention} broke the chain! start a new chain with `.chain <thing>`. Chain length: {length}")
                 await msg.add_reaction("❌")
-                await msg.channel.send(f"{msg.author.mention} broke the chain! start a new chain with `.chain <thing>`. Chain length: {length}")
                 break_role = await db.fetchval("SELECT chain_break_role FROM guilds WHERE id = $1", msg.guild.id)
                 if break_role is not None:
                     await msg.author.add_roles(msg.guild.get_role(break_role))
-                await db.execute("UPDATE channels SET chain = NULL, chain_length = 0 WHERE id = $1", msg.channel.id)
+                await db.execute("UPDATE channels SET chain = $2, chain_length = 0 WHERE id = $1", msg.channel.id, forever)
 
             if chain is None or msg.author.bot:
                 return
             if chain.startswith("$counting:"):
                 num = int(chain.split(":")[1])
-                if msg.content != str(num + 1):
+                if msg.content != str(num):
                     return await cbreak()
                 num += 1
-                await db.execute("UPDATE channels SET chain = $2 WHERE id = $1", msg.channel.id, f"$counting:{num}")
+                chain = f"$counting:{num}"
+                await db.execute("UPDATE channels SET chain = $2 WHERE id = $1", msg.channel.id, chain)
             elif msg.content != chain:
                 return await cbreak()
             if msg.author.id == await db.fetchval("SELECT last_chain FROM channels WHERE id = $1", msg.channel.id):
                 return await cbreak()
             await db.execute("UPDATE channels SET last_chain = $2, chain_length = chain_length + 1 WHERE id = $1", msg.channel.id, msg.author.id)
-            if msg.content == "100" or length == 100:
+            if (msg.content == "100" and chain.startswith("$")) or length == 100:
                 await msg.add_reaction("💯")
             else:
                 await msg.add_reaction("✅")

--- a/bot/_Util.py
+++ b/bot/_Util.py
@@ -13,39 +13,39 @@ class Checks:
     Permission checks
     """
     @staticmethod
-    async def trusted(ctx):
+    async def trusted(ctx, bot=None):
         """
         Check to see if the user is trusted
         """
-        async with ctx.bot.pool.acquire() as db:
+        async with (bot if bot is not None else ctx.bot).pool.acquire() as db:
             return await db.fetchval("SELECT trusted FROM users WHERE id = $1", ctx.author.id)
 
     @staticmethod
-    async def mod(ctx):
+    async def mod(ctx, bot=None):
         """
         Check to see if the user is a mod
         """
-        async with ctx.bot.pool.acquire() as db:
+        async with (bot if bot is not None else ctx.bot).pool.acquire() as db:
             for role in await db.fetchval("SELECT mod_roles FROM guilds WHERE id = $1", ctx.guild.id):
                 if role in [r.id for r in ctx.author.roles]:
                     return True
             return False
 
     @staticmethod
-    async def admin(ctx):
+    async def admin(ctx, bot=None):
         """
         Check to see if the user is an admin
         """
-        async with ctx.bot.pool.acquire() as db:
+        async with (bot if bot is not None else ctx.bot).pool.acquire() as db:
             for role in await db.fetchval("SELECT admin_roles FROM guilds WHERE id = $1", ctx.guild.id):
                 if role in [r.id for r in ctx.author.roles]:
                     return True
             return False
 
     @staticmethod
-    async def slash(ctx):
+    async def slash(ctx, bot=None):
         """
         Check to see if command has slash command alternative
         """
-        async with ctx.bot.pool.acquire() as db:
+        async with (bot if bot is not None else ctx.bot).pool.acquire() as db:
             return not await db.fetchval("SELECT force_slash FROM guilds WHERE id = $1", ctx.guild.id)


### PR DESCRIPTION
Makes chains better. Adds `.chainforever` to allow admins to make a chain repeat upon breakage and fixed counting.
`.chainforever` also pins when a chain is broken if the chain was longer than the value set in the environment variables.

Fixes #146 
Implements #99 